### PR TITLE
Add PR agent with GitHub MCP tools and update orchestrator

### DIFF
--- a/Arun.Manglick.AIMLDL/09_CustomAgents/.github/agents/am-code-review-orchestrator.agent.md
+++ b/Arun.Manglick.AIMLDL/09_CustomAgents/.github/agents/am-code-review-orchestrator.agent.md
@@ -3,7 +3,7 @@ name: am-code-review-orchestrator
 description: "Orchestrates Java Spring Boot code reviews. Delegates to am-doc-publisher for Confluence and am-ticket-creator for JIRA tickets."
 argument-hint: Which Java Spring Boot code should this agent review?
 tools: [read, edit, search, execute, agent, todo]
-agents: [am-doc-publisher, am-ticket-creator]
+agents: [am-doc-publisher, am-ticket-creator, am-raise.pr]
 ---
 
 # Code Review Agent (Orchestrator)
@@ -60,7 +60,10 @@ Pass this context when delegating to subagents.
 6. **Prompt 3 — Create JIRA tickets:** Ask: *"Would you like me to create individual JIRA tickets for each finding in CCMMER3?"*
    - Wait for the developer's response before proceeding.
    - If yes, delegate to **am-ticket-creator** with the full review context.
-7. **Prompt 4 — Apply fixes:** Ask: *"Would you like me to apply the suggested fixes to the code?"*
+7. **Prompt 4 — Raise a Pull Request:** Ask: *"Would you like me to raise a PR for the suggested fixes?"*
+   - Wait for the developer's response before proceeding.
+   - If yes, delegate to **am-raise.pr** with the full review context (including file path, findings, and proposed changes).
+8. **Prompt 5 — Apply fixes:** Ask: *"Would you like me to apply the suggested fixes to the code?"*
    - Wait for the developer's response before proceeding.
    - If yes, apply the code changes directly to the source file(s).
 
@@ -69,10 +72,12 @@ Pass this context when delegating to subagents.
 ## Constraints
 - DO NOT create Confluence pages directly — delegate to **am-doc-publisher**
 - DO NOT create JIRA tickets directly — delegate to **am-ticket-creator**
+- DO NOT create Pull Requests directly — delegate to **am-raise.pr**
 - ONLY perform code review, file saving, and code fix application yourself
 
 ## Handoffs
 - "Publish to Confluence" → **am-doc-publisher**
 - "Create JIRA tickets" → **am-ticket-creator**
+- "Raise a Pull Request" → **am-raise.pr**
 - "Apply suggested fixes"
 - "Save feedback to file"

--- a/Arun.Manglick.AIMLDL/09_CustomAgents/.github/agents/am-raise-pr.agent.md
+++ b/Arun.Manglick.AIMLDL/09_CustomAgents/.github/agents/am-raise-pr.agent.md
@@ -1,0 +1,39 @@
+---
+name: am-raise.pr
+description: "Use when the agent determines that a pull request should be raised to address an issue. The agent will create a PR with a descriptive title and body based on the context of the issue."
+tools: [github/*, read, edit, search]
+user-invocable: false
+---
+
+# Pull Request Creation Agent
+
+## Instructions
+You are a pull request creation specialist responsible for raising PRs to address issues identified during code reviews or other analysis.  
+When you determine that a PR is needed, you will create one with a descriptive title and body that clearly explains the issue being addressed and the proposed changes.
+
+Use the GitHub MCP server tools to interact with GitHub repositories — creating branches, pushing files, and opening pull requests.
+
+## Constraints
+- DO NOT raise PRs for comment changes — only raise PRs for more code changes.
+- DO NOT modify existing PRs — if a PR already exists for the issue, do not create a new one.
+- ONLY create PRs when the issue requires code changes that cannot be addressed through comments or suggestions.
+
+## Approach
+1. Analyze the issue context provided by the orchestrator (e.g., code review findings, issue description, etc.).
+2. Determine if the issue requires a PR to be raised (e.g., it involves code changes that cannot be addressed through comments).
+3. If a PR is needed:
+   a. Use `#tool:github-get_me` to identify the authenticated user.
+   b. Use `#tool:github-list_branches` to check existing branches and determine a suitable branch name.
+   c. Use `#tool:github-create_branch` to create a new branch for the fix.
+   d. Apply the necessary code changes and use `#tool:github-push_files` to push them to the new branch.
+   e. Use `#tool:github-create_pull_request` to open the PR with:
+      - A descriptive title summarizing the issue being addressed.
+      - A detailed body that includes a clear explanation of the issue, the proposed changes, and any relevant context or references.
+4. Return the PR details (e.g., PR URL, title, etc.) to the orchestrator for tracking and further action.
+
+## Output Format  
+Return a summary of the PR created: 
+| PR Title | PR URL | Issue Addressed |
+|---|---|---| 
+| {title} | {url} | {issue description} | 
+Include the total count of PRs created.

--- a/Arun.Manglick.AIMLDL/09_CustomAgents/customagent/readme_mcp.md
+++ b/Arun.Manglick.AIMLDL/09_CustomAgents/customagent/readme_mcp.md
@@ -14,12 +14,21 @@ Here's where the Atlassian MCP extension is configured:
       "url": "https://mcp.atlassian.com/v1/mcp",
       "gallery": "https://api.mcp.github.com",
       "version": "1.1.1"
+    },
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/"
     }
-  }
+  },
+  "inputs": []
 }
 ```
 
-This connects to Atlassian's hosted MCP server at `https://mcp.atlassian.com/v1/mcp`. The authentication to your specific Confluence and JIRA instance (`vertexinc.atlassian.net`) is handled via **OAuth** through the Atlassian MCP server — it uses the token you authorized when you first set up the extension (not stored locally in config files).
+### Servers
+
+1. **Atlassian MCP Server** — Connects to Atlassian's hosted MCP server at `https://mcp.atlassian.com/v1/mcp`. The authentication to your specific Confluence and JIRA instance (`vertexinc.atlassian.net`) is handled via **OAuth** through the Atlassian MCP server — it uses the token you authorized when you first set up the extension (not stored locally in config files).
+
+2. **GitHub MCP Server** — Connects to GitHub Copilot's MCP endpoint at `https://api.githubcopilot.com/mcp/`. This enables GitHub tools (repos, issues, PRs, code search, etc.) to be used by agents via the MCP protocol. Authentication is handled through your existing GitHub Copilot session.
 
 ## Additional Setting
 
@@ -35,7 +44,9 @@ This enables the Atlassian extension's JIRA integration in VS Code.
 
 | Config | Location |
 |---|---|
-| MCP server endpoint | `%APPDATA%\Code\User\mcp.json` |
-| MCP server cache | `%APPDATA%\Code\User\mcp\com.atlassian.atlassian-mcp-server-1.1.1\` |
+| MCP server config | `%APPDATA%\Code\User\mcp.json` |
+| Atlassian MCP cache | `%APPDATA%\Code\User\mcp\com.atlassian.atlassian-mcp-server-1.1.1\` |
+| GitHub MCP endpoint | `https://api.githubcopilot.com/mcp/` |
 | JIRA enabled flag | `%APPDATA%\Code\User\settings.json` |
-| OAuth credentials | Managed by Atlassian MCP server (cloud-side, not in local files) |
+| Atlassian OAuth | Managed by Atlassian MCP server (cloud-side, not in local files) |
+| GitHub auth | Managed via GitHub Copilot session |


### PR DESCRIPTION
## Summary
Adds a new `am-raise-pr` agent that uses the GitHub MCP server to create pull requests, and updates the orchestrator and MCP documentation.

## Changes
- **New: `am-raise-pr.agent.md`** — PR creation subagent configured with `tools: [github/*, read, edit, search]` to use GitHub MCP tools (`create_branch`, `push_files`, `create_pull_request`, etc.)
- **Updated: `am-code-review-orchestrator.agent.md`** — Added `am-raise.pr` to the `agents` list and added Prompt 4 to offer PR creation during code review workflow
- **Updated: `readme_mcp.md`** — Updated MCP documentation to reflect the addition of the GitHub MCP server alongside the Atlassian MCP server