### PR TITLE
fix: StudentController code review fixes (CR-001 to CR-008)

### DIFF
--- a/Arun.Manglick.AIMLDL/09_CustomAgents/customagent/src/main/java/com/spring/customagent/controller/StudentController.java
+++ b/Arun.Manglick.AIMLDL/09_CustomAgents/customagent/src/main/java/com/spring/customagent/controller/StudentController.java
@@ -1,16 +1,18 @@
 package com.spring.customagent.controller;
 
 import com.spring.customagent.entity.Student;
+import com.spring.customagent.request.StudentRequest;
 import com.spring.customagent.service.StudentService;
 
-import java.util.List;
-
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
+@RequestMapping("/student")
 public class StudentController {
 
     private final StudentService studentService;
@@ -19,19 +21,53 @@ public class StudentController {
         this.studentService = studentService;
     }
 
-    @GetMapping("/student")
-    public String helloStudent() {
-        return "Hello, Student REST Controller SpringBoot Project!";
-    }
-    
-    @GetMapping("/student/list")
-    public List<Student> listStudents() {
-        return studentService.getAllStudents();
+    @GetMapping("/list")
+    public Page<Student> listStudents(Pageable pageable) {
+        return studentService.getAllStudents(pageable);
     }
 
+    @GetMapping("/{id}")
+    public Student getStudent(@PathVariable Long id) {
+        Student student = studentService.getStudentById(id);
+        if (student == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Student not found with id: " + id);
+        }
+        return student;
+    }
 
-    @PostMapping("/student/add")
-    public Student addStudent(@RequestBody Student student) {
+    @PostMapping("/add")
+    @ResponseStatus(HttpStatus.CREATED)
+    public Student addStudent(@RequestBody @Valid StudentRequest request) {
+        Student student = new Student(
+                request.getFirstname(),
+                request.getLastname(),
+                request.getEmail(),
+                request.getAge(),
+                "ACTIVE"
+        );
         return studentService.addStudent(student);
+    }
+
+    @PutMapping("/{id}")
+    public Student updateStudent(@PathVariable Long id, @RequestBody @Valid StudentRequest request) {
+        Student existing = studentService.getStudentById(id);
+        if (existing == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Student not found with id: " + id);
+        }
+        existing.setFirstname(request.getFirstname());
+        existing.setLastname(request.getLastname());
+        existing.setEmail(request.getEmail());
+        existing.setAge(request.getAge());
+        return studentService.updateStudent(existing);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteStudent(@PathVariable Long id) {
+        Student existing = studentService.getStudentById(id);
+        if (existing == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Student not found with id: " + id);
+        }
+        studentService.deleteStudent(id);
     }
 }

--- a/Arun.Manglick.AIMLDL/09_CustomAgents/customagent/src/main/java/com/spring/customagent/request/StudentRequest.java
+++ b/Arun.Manglick.AIMLDL/09_CustomAgents/customagent/src/main/java/com/spring/customagent/request/StudentRequest.java
@@ -1,0 +1,33 @@
+package com.spring.customagent.request;
+
+import jakarta.validation.constraints.*;
+
+public class StudentRequest {
+
+    @NotBlank(message = "First name is required")
+    private String firstname;
+
+    @NotBlank(message = "Last name is required")
+    private String lastname;
+
+    @NotBlank(message = "Email is required")
+    @Email(message = "Email must be a valid email address")
+    private String email;
+
+    @NotNull(message = "Age is required")
+    @Min(value = 0, message = "Age must be at least 0")
+    @Max(value = 150, message = "Age must be at most 150")
+    private Integer age;
+
+    public String getFirstname() { return firstname; }
+    public void setFirstname(String firstname) { this.firstname = firstname; }
+
+    public String getLastname() { return lastname; }
+    public void setLastname(String lastname) { this.lastname = lastname; }
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public Integer getAge() { return age; }
+    public void setAge(Integer age) { this.age = age; }
+}

--- a/Arun.Manglick.AIMLDL/09_CustomAgents/customagent/src/main/java/com/spring/customagent/service/StudentService.java
+++ b/Arun.Manglick.AIMLDL/09_CustomAgents/customagent/src/main/java/com/spring/customagent/service/StudentService.java
@@ -1,12 +1,15 @@
 package com.spring.customagent.service;
 
 import com.spring.customagent.entity.Student;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface StudentService {
-    List<Student> getAllStudents();
+    Page<Student> getAllStudents(Pageable pageable);
     List<Student> getStudentByName(String firstname);
+    Student getStudentById(Long id);
     Student addStudent(Student student);
     Student updateStudent(Student student);
     void deleteStudent(Long id);

--- a/Arun.Manglick.AIMLDL/09_CustomAgents/customagent/src/main/java/com/spring/customagent/service/StudentServiceImpl.java
+++ b/Arun.Manglick.AIMLDL/09_CustomAgents/customagent/src/main/java/com/spring/customagent/service/StudentServiceImpl.java
@@ -3,6 +3,9 @@ package com.spring.customagent.service;
 import com.spring.customagent.dao.StudentDAO;
 import com.spring.customagent.entity.Student;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -14,13 +17,22 @@ public class StudentServiceImpl implements StudentService {
     private StudentDAO studentDAO;
 
     @Override
-    public List<Student> getAllStudents() {
-        return studentDAO.getAllStudents();
+    public Page<Student> getAllStudents(Pageable pageable) {
+        List<Student> all = studentDAO.getAllStudents();
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), all.size());
+        List<Student> pageContent = (start > all.size()) ? List.of() : all.subList(start, end);
+        return new PageImpl<>(pageContent, pageable, all.size());
     }
 
     @Override
     public List<Student> getStudentByName(String firstname) {
         return studentDAO.getStudentsByFirstname(firstname);
+    }
+
+    @Override
+    public Student getStudentById(Long id) {
+        return studentDAO.getStudentById(id);
     }
 
     @Override


### PR DESCRIPTION
## Code Review Fixes — StudentController

This PR addresses all findings from the code review of `StudentController.java` conducted on **2026-06-29**.

---

### Changes Made

#### `StudentController.java`
| Review ID | Fix Applied |
|---|---|
| CR-001 | Added `@RequestMapping("/student")` at class level; removed `/student` prefix from individual method mappings |
| CR-002 | Removed `helloStudent()` debug endpoint |
| CR-003 | Added `@ResponseStatus(HttpStatus.CREATED)` to `addStudent` |
| CR-004 | Changed `addStudent` to accept `@RequestBody @Valid StudentRequest` instead of raw `Student` entity |
| CR-005 | Changed `listStudents` to accept `Pageable` and return `Page<Student>` to prevent unbounded queries |
| CR-006 | Added `GET /{id}` endpoint with `ResponseStatusException(NOT_FOUND)` |
| CR-007 | Added `PUT /{id}` endpoint with `ResponseStatusException(NOT_FOUND)` |
| CR-008 | Added `DELETE /{id}` endpoint with `@ResponseStatus(NO_CONTENT)` and `ResponseStatusException(NOT_FOUND)` |

#### `StudentRequest.java` _(new)_
- DTO with `firstname`, `lastname`, `email`, `age` fields
- Annotated with `@NotBlank`, `@Email`, `@Min(0)`, `@Max(150)` for Bean Validation

#### `StudentService.java` _(minimal update to support new endpoints)_
- Changed `getAllStudents()` → `getAllStudents(Pageable pageable)` returning `Page<Student>`
- Added `getStudentById(Long id)` method

#### `StudentServiceImpl.java` _(minimal update)_
- Implemented paginated `getAllStudents` using `PageImpl` over the DAO list
- Implemented `getStudentById` delegating to `StudentDAO`

---

### JIRA Tickets
- [CCMMER3-9768](https://vertexinc.atlassian.net/browse/CCMMER3-9768) — Missing `@RequestMapping` at class level
- [CCMMER3-9769](https://vertexinc.atlassian.net/browse/CCMMER3-9769) — Debug endpoint `helloStudent()` exposed in production
- [CCMMER3-9770](https://vertexinc.atlassian.net/browse/CCMMER3-9770) — `addStudent` missing `@ResponseStatus(CREATED)`
- [CCMMER3-9771](https://vertexinc.atlassian.net/browse/CCMMER3-9771) — `addStudent` accepts raw entity instead of validated DTO
- [CCMMER3-9772](https://vertexinc.atlassian.net/browse/CCMMER3-9772) — `listStudents` returns unbounded list without pagination
- [CCMMER3-9773](https://vertexinc.atlassian.net/browse/CCMMER3-9773) — Missing `GET /{id}` endpoint
- [CCMMER3-9774](https://vertexinc.atlassian.net/browse/CCMMER3-9774) — Missing `PUT /{id}` endpoint
- [CCMMER3-9775](https://vertexinc.atlassian.net/browse/CCMMER3-9775) — Missing `DELETE /{id}` endpoint

---

### Confluence Review Page
[Code Review: StudentController — 2026-06-29](https://vertexinc.atlassian.net/wiki/x/RAB3pAE)