### PR TITLE
[Code Review Fix] StudentRepository.java — header, annotation, Javadoc

### DIFF
--- a/Arun.Manglick.AIMLDL/09_CustomAgents/customagent/src/main/java/com/spring/customagent/repository/StudentRepository.java
+++ b/Arun.Manglick.AIMLDL/09_CustomAgents/customagent/src/main/java/com/spring/customagent/repository/StudentRepository.java
@@ -1,12 +1,28 @@
+/*
+ * Author: Arun Manglick
+ * Created: 2026-06-29
+ * Updated: 2026-06-29
+ */
 package com.spring.customagent.repository;
 
 import com.spring.customagent.entity.Student;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-@Repository
+/**
+ * Spring Data JPA repository for the {@link Student} entity.
+ *
+ * <p><strong>NOTE:</strong> This repository is <em>NOT</em> part of the active code path.
+ * The application uses a manual DAO pattern via
+ * {@link com.spring.customagent.dao.StudentDAOImpl} backed by JPA {@code EntityManager}.
+ * This interface is retained for reference/demonstration purposes only and should not
+ * be injected into production service classes.</p>
+ *
+ * @deprecated Not wired into the active service chain. Use
+ *             {@link com.spring.customagent.dao.StudentDAO} instead.
+ */
+@Deprecated
 public interface StudentRepository extends JpaRepository<Student, Long> {
     List<Student> findByFirstname(String firstname);
 }


### PR DESCRIPTION
## Summary

Addresses code review findings for `StudentRepository.java` from the review conducted on 2026-06-29.

- **CR-003**: Added the required file header comment block (Author: Arun Manglick, Created/Updated: 2026-06-29) per project conventions.
- **CR-004**: Removed the redundant `@Repository` annotation. Spring Data JPA automatically detects `JpaRepository` interfaces and creates proxy beans — the annotation was unnecessary.
- **CR-006**: Added a class-level Javadoc explaining that this repository is NOT part of the active code path (the app uses the manual DAO pattern via `StudentDAOImpl`). Added `@Deprecated` annotation to clearly signal inactive status.

## Out of Scope

- **CR-001 / CR-005** (Architecture — remove or migrate the repository): Requires a broader architectural decision.
- **CR-002** (Rename `firstname` to `firstName`): Cross-cutting refactor affecting entity, DAO, and query layers.

## Review Tickets

- CR-003 (Missing file header comment block)
- CR-004 (Redundant `@Repository` annotation)
- CR-006 (Missing Javadoc and deprecation marker)

## Test Plan

- [ ] Verify the application starts successfully (mvnw spring-boot:run)
- [ ] Verify StudentRepository bean is still created by Spring Data JPA (no @Repository needed)
- [ ] Confirm no runtime regressions in the active code path (StudentController -> StudentServiceImpl -> StudentDAOImpl)

Generated with Claude Code (https://claude.com/claude-code)